### PR TITLE
Update Windows linter version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-12]
 
     steps:
       - uses: actions/setup-go@v4
@@ -71,8 +71,12 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update test to run on latest Windows version and run linters on 2019