### PR TITLE
enable linter on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     steps:
       - uses: actions/setup-go@v4


### PR DESCRIPTION
- add windows-2022 runner for linting
- set line endings while checking out via `.gitattributes` to fix lint issues in windows