### PR TITLE
Fix windows matching when os version is empty

### DIFF
--- a/compare_test.go
+++ b/compare_test.go
@@ -78,7 +78,10 @@ func TestOnly(t *testing.T) {
 		{
 			platform: "windows/amd64",
 			matches: map[bool][]string{
-				true: {"windows/amd64"},
+				true: {
+					"windows/amd64",
+					"windows(10.0.17763)/amd64",
+				},
 				false: {
 					"linux/amd64",
 					"linux/arm/v7",
@@ -265,7 +268,25 @@ func TestOnlyStrict(t *testing.T) {
 		{
 			platform: "windows/amd64",
 			matches: map[bool][]string{
-				true: {"windows/amd64"},
+				true: {
+					"windows/amd64",
+					"windows(10.0.17763)/amd64",
+				},
+				false: {
+					"linux/amd64",
+					"linux/arm/v7",
+					"linux/arm64",
+					"windows/arm",
+				},
+			},
+		},
+		{
+			platform: "windows(10.0.17763)/amd64",
+			matches: map[bool][]string{
+				true: {
+					"windows/amd64",
+					"windows(10.0.17763)/amd64",
+				},
 				false: {
 					"linux/amd64",
 					"linux/arm/v7",

--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -52,7 +52,7 @@ func (m windowsmatcher) Match(p specs.Platform) bool {
 
 	if match && m.OS == "windows" {
 		// HPC containers do not have OS version filled
-		if p.OSVersion == "" {
+		if m.OSVersion == "" || p.OSVersion == "" {
 			return true
 		}
 

--- a/defaults_windows_test.go
+++ b/defaults_windows_test.go
@@ -145,6 +145,10 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 // TestMatchComparerMatch_ABICheckWCOW checks windows platform matcher
 // behavior for stable ABI and non-stable ABI compliant versions
 func TestMatchComparerMatch_ABICheckWCOW(t *testing.T) {
+	platformNoVersion := imagespec.Platform{
+		Architecture: "amd64",
+		OS:           "windows",
+	}
 	platformWS2019 := imagespec.Platform{
 		Architecture: "amd64",
 		OS:           "windows",
@@ -160,6 +164,7 @@ func TestMatchComparerMatch_ABICheckWCOW(t *testing.T) {
 		OS:           "windows",
 		OSVersion:    "10.0.22621",
 	}
+	matcherNoVersion := NewMatcher(platformNoVersion).(windowsmatcher)
 	matcherWS2019 := windowsmatcher{
 		Platform:        platformWS2019,
 		osVersionPrefix: platformWS2019.OSVersion,
@@ -240,6 +245,21 @@ func TestMatchComparerMatch_ABICheckWCOW(t *testing.T) {
 				OSVersion:    "10.0.20348",
 			},
 			match: true,
+		},
+		{
+			hostPlatformMatcher: matcherNoVersion,
+			testPlatform:        platformWS2019,
+			match:               true,
+		},
+		{
+			hostPlatformMatcher: matcherNoVersion,
+			testPlatform:        platformNoVersion,
+			match:               true,
+		},
+		{
+			hostPlatformMatcher: matcherNoVersion,
+			testPlatform:        platformWindows11,
+			match:               true,
 		},
 	} {
 		assert.Equal(t, test.match, test.hostPlatformMatcher.Match(test.testPlatform), "should match: %t, %s to %s", test.match, test.hostPlatformMatcher.Platform, test.testPlatform)


### PR DESCRIPTION
Add unit tests to match a case in configuration where the target to match does not specify an os version.