### PR TITLE
Add support for OS Features in the format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/platforms
 
-go 1.20
+go 1.21
 
 require (
 	github.com/containerd/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -21,3 +21,4 @@ golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/platforms.go
+++ b/platforms.go
@@ -121,11 +121,9 @@ import (
 )
 
 var (
-	specifierRe    = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
-	osAndVersionRe = regexp.MustCompile(`^([A-Za-z0-9_-]+)(?:\(([A-Za-z0-9_.-]*)\))?$`)
+	specifierRe = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	osRe        = regexp.MustCompile(`^([A-Za-z0-9_-]+)(?:\(([A-Za-z0-9_.-]*)((?:\+[A-Za-z0-9_.-]+)*)\))?$`)
 )
-
-const osAndVersionFormat = "%s(%s)"
 
 // Platform is a type alias for convenience, so there is no need to import image-spec package everywhere.
 type Platform = specs.Platform
@@ -210,11 +208,14 @@ func ParseAll(specifiers []string) ([]specs.Platform, error) {
 
 // Parse parses the platform specifier syntax into a platform declaration.
 //
-// Platform specifiers are in the format `<os>[(<OSVersion>)]|<arch>|<os>[(<OSVersion>)]/<arch>[/<variant>]`.
+// Platform specifiers are in the format `<os>[(<os options>)]|<arch>|<os>[(<os options>)]/<arch>[/<variant>]`.
 // The minimum required information for a platform specifier is the operating
-// system or architecture. The OSVersion can be part of the OS like `windows(10.0.17763)`
-// When an OSVersion is specified, then specs.Platform.OSVersion is populated with that value,
-// and an empty string otherwise.
+// system or architecture. The "os options" may be OSVersion which can be part of the OS
+// like `windows(10.0.17763)`. When an OSVersion is specified, then specs.Platform.OSVersion is
+// populated with that value, and an empty string otherwise. The "os options" may also include an
+// array of OSFeatures, each feature prefixed with '+', without any other separator, and provided
+// after the OSVersion when the OSVersion is specified. An "os options" with version and features
+// is like `windows(10.0.17763+win32k)`.
 // If there is only a single string (no slashes), the
 // value will be matched against the known set of operating systems, then fall
 // back to the known set of architectures. The missing component will be
@@ -231,14 +232,17 @@ func Parse(specifier string) (specs.Platform, error) {
 	var p specs.Platform
 	for i, part := range parts {
 		if i == 0 {
-			// First element is <os>[(<OSVersion>)]
-			osVer := osAndVersionRe.FindStringSubmatch(part)
-			if osVer == nil {
-				return specs.Platform{}, fmt.Errorf("%q is an invalid OS component of %q: OSAndVersion specifier component must match %q: %w", part, specifier, osAndVersionRe.String(), errInvalidArgument)
+			// First element is <os>[(<OSVersion>[+<OSFeature>]*)]
+			osOptions := osRe.FindStringSubmatch(part)
+			if osOptions == nil {
+				return specs.Platform{}, fmt.Errorf("%q is an invalid OS component of %q: OSAndVersion specifier component must match %q: %w", part, specifier, osRe.String(), errInvalidArgument)
 			}
 
-			p.OS = normalizeOS(osVer[1])
-			p.OSVersion = osVer[2]
+			p.OS = normalizeOS(osOptions[1])
+			p.OSVersion = osOptions[2]
+			if osOptions[3] != "" {
+				p.OSFeatures = strings.Split(osOptions[3][1:], "+")
+			}
 		} else {
 			if !specifierRe.MatchString(part) {
 				return specs.Platform{}, fmt.Errorf("%q is an invalid component of %q: platform specifier component must match %q: %w", part, specifier, specifierRe.String(), errInvalidArgument)
@@ -322,8 +326,12 @@ func FormatAll(platform specs.Platform) string {
 		return "unknown"
 	}
 
-	if platform.OSVersion != "" {
-		OSAndVersion := fmt.Sprintf(osAndVersionFormat, platform.OS, platform.OSVersion)
+	osOptions := platform.OSVersion
+	for _, feature := range platform.OSFeatures {
+		osOptions += "+" + feature
+	}
+	if osOptions != "" {
+		OSAndVersion := fmt.Sprintf("%s(%s)", platform.OS, osOptions)
 		return path.Join(OSAndVersion, platform.Architecture, platform.Variant)
 	}
 	return path.Join(platform.OS, platform.Architecture, platform.Variant)

--- a/platforms.go
+++ b/platforms.go
@@ -114,6 +114,7 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -327,8 +328,13 @@ func FormatAll(platform specs.Platform) string {
 	}
 
 	osOptions := platform.OSVersion
-	for _, feature := range platform.OSFeatures {
-		osOptions += "+" + feature
+	features := platform.OSFeatures
+	if !slices.IsSorted(features) {
+		features = slices.Clone(features)
+		slices.Sort(features)
+	}
+	if len(features) > 0 {
+		osOptions += "+" + strings.Join(features, "+")
 	}
 	if osOptions != "" {
 		OSAndVersion := fmt.Sprintf("%s(%s)", platform.OS, osOptions)

--- a/platforms_test.go
+++ b/platforms_test.go
@@ -343,6 +343,42 @@ func TestParseSelector(t *testing.T) {
 			formatted:   path.Join("windows(10.0.17763)", defaultArch, defaultVariant),
 			useV2Format: true,
 		},
+		{
+			input: "windows(10.0.17763+win32k)",
+			expected: specs.Platform{
+				OS:           "windows",
+				OSVersion:    "10.0.17763",
+				OSFeatures:   []string{"win32k"},
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
+			},
+			formatted:   path.Join("windows(10.0.17763+win32k)", defaultArch, defaultVariant),
+			useV2Format: true,
+		},
+		{
+			input: "linux(+gpu)",
+			expected: specs.Platform{
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{"gpu"},
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
+			},
+			formatted:   path.Join("linux(+gpu)", defaultArch, defaultVariant),
+			useV2Format: true,
+		},
+		{
+			input: "linux(+gpu+simd)",
+			expected: specs.Platform{
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{"gpu", "simd"},
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
+			},
+			formatted:   path.Join("linux(+gpu+simd)", defaultArch, defaultVariant),
+			useV2Format: true,
+		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {
 			if testcase.skip {

--- a/platforms_test.go
+++ b/platforms_test.go
@@ -379,6 +379,18 @@ func TestParseSelector(t *testing.T) {
 			formatted:   path.Join("linux(+gpu+simd)", defaultArch, defaultVariant),
 			useV2Format: true,
 		},
+		{
+			input: "linux(+unsorted+erofs)",
+			expected: specs.Platform{
+				OS:           "linux",
+				OSVersion:    "",
+				OSFeatures:   []string{"unsorted", "erofs"},
+				Architecture: defaultArch,
+				Variant:      defaultVariant,
+			},
+			formatted:   path.Join("linux(+erofs+unsorted)", defaultArch, defaultVariant),
+			useV2Format: true,
+		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {
 			if testcase.skip {


### PR DESCRIPTION
Updates the os part of the format to include features after the os version. The guarantees that the format may fully represent the platform structure.

I propose we consider including the features in the format for 1.0 release, which we are trying to finalize.

Should we consider "/" or "+" as supported parts of OS features here? Right now the spec does not specify but we can define our own limitations. We could support it either by updating the parser (less backwards compatible) or URL encoding (ugly, but could be an edge case so who cares). 