### PR TITLE
replace testify with stdlib in tests

### DIFF
--- a/defaults_windows_test.go
+++ b/defaults_windows_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/windows"
 )
 
@@ -66,7 +65,9 @@ func TestDefaultMatchComparer(t *testing.T) {
 			match: false,
 		},
 	} {
-		assert.Equal(t, test.match, defaultMatcher.Match(test.platform))
+		if actual := defaultMatcher.Match(test.platform); actual != test.match {
+			t.Errorf("expected: %v, actual: %v", test.match, actual)
+		}
 	}
 
 }
@@ -138,7 +139,9 @@ func TestMatchComparerMatch_WCOW(t *testing.T) {
 			match: false,
 		},
 	} {
-		assert.Equal(t, test.match, m.Match(test.platform), "should match: %t, %s to %s", test.match, m.Platform, test.platform)
+		if actual := m.Match(test.platform); actual != test.match {
+			t.Errorf("should match: %t, %s to %s", test.match, m.Platform, test.platform)
+		}
 	}
 }
 
@@ -262,7 +265,9 @@ func TestMatchComparerMatch_ABICheckWCOW(t *testing.T) {
 			match:               true,
 		},
 	} {
-		assert.Equal(t, test.match, test.hostPlatformMatcher.Match(test.testPlatform), "should match: %t, %s to %s", test.match, test.hostPlatformMatcher.Platform, test.testPlatform)
+		if actual := test.hostPlatformMatcher.Match(test.testPlatform); actual != test.match {
+			t.Errorf("should match: %t, %s to %s", test.match, test.hostPlatformMatcher.Platform, test.testPlatform)
+		}
 	}
 }
 
@@ -323,7 +328,9 @@ func TestMatchComparerMatch_LCOW(t *testing.T) {
 			match: true,
 		},
 	} {
-		assert.Equal(t, test.match, m.Match(test.platform), "should match %b, %s to %s", test.match, m.Platform, test.platform)
+		if actual := m.Match(test.platform); actual != test.match {
+			t.Errorf("should match: %t, %s to %s", test.match, m.Platform, test.platform)
+		}
 	}
 }
 
@@ -390,5 +397,7 @@ func TestMatchComparerLess(t *testing.T) {
 	sort.SliceStable(platforms, func(i, j int) bool {
 		return m.Less(platforms[i], platforms[j])
 	})
-	assert.Equal(t, expected, platforms)
+	if !reflect.DeepEqual(platforms, expected) {
+		t.Errorf("expected: %s\nactual  : %s", expected, platforms)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,11 @@ go 1.20
 require (
 	github.com/containerd/log v0.1.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.26.0
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/platforms_windows_test.go
+++ b/platforms_windows_test.go
@@ -17,14 +17,18 @@
 package platforms
 
 import (
+	"reflect"
 	"testing"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNormalize(t *testing.T) {
-	require.Equal(t, DefaultSpec(), Normalize(DefaultSpec()))
+	s := DefaultSpec()
+	n := Normalize(DefaultSpec())
+	if !reflect.DeepEqual(s, n) {
+		t.Errorf("Normalize returned %+v, expected %+v", n, s)
+	}
 }
 
 func TestFallbackOnOSVersion(t *testing.T) {
@@ -37,5 +41,7 @@ func TestFallbackOnOSVersion(t *testing.T) {
 	other := specs.Platform{OS: p.OS, Architecture: p.Architecture}
 
 	m := NewMatcher(p)
-	require.True(t, m.Match(other))
+	if !m.Match(other) {
+		t.Errorf("Expected %+v to match", other)
+	}
 }


### PR DESCRIPTION
Looks like we only minimally depended on testify, so we might as well use stdlib.