### PR TITLE
Add WS2025 to Windows matcher and code optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Go version we currently use to build containerd across all CI.
   # Note: don't forget to update `Binaries` step, as it contains the matrix of all supported Go versions.
-  GO_VERSION: "1.22.8"
+  GO_VERSION: "1.23.9"
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
@@ -64,7 +64,7 @@ jobs:
           path: src/github.com/containerd/platforms
           fetch-depth: 25
 
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@v1.2.2
         with:
           working-directory: src/github.com/containerd/platforms
           repo-access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/platform_windows_compat.go
+++ b/platform_windows_compat.go
@@ -42,18 +42,30 @@ const (
 	// rs5 (version 1809, codename "Redstone 5") corresponds to Windows Server
 	// 2019 (ltsc2019), and Windows 10 (October 2018 Update).
 	rs5 = 17763
+	// ltsc2019 (Windows Server 2019) is an alias for [RS5].
+	ltsc2019 = rs5
 
 	// v21H2Server corresponds to Windows Server 2022 (ltsc2022).
 	v21H2Server = 20348
+	// ltsc2022 (Windows Server 2022) is an alias for [v21H2Server]
+	ltsc2022 = v21H2Server
 
 	// v22H2Win11 corresponds to Windows 11 (2022 Update).
 	v22H2Win11 = 22621
+
+	// v23H2 is the 23H2 release in the Windows Server annual channel.
+	v23H2 = 25398
+
+	// Windows Server 2025 build 26100
+	v25H1Server = 26100
+	ltsc2025    = v25H1Server
 )
 
 // List of stable ABI compliant ltsc releases
 // Note: List must be sorted in ascending order
 var compatLTSCReleases = []uint16{
-	v21H2Server,
+	ltsc2022,
+	ltsc2025,
 }
 
 // CheckHostAndContainerCompat checks if given host and container
@@ -70,18 +82,27 @@ func checkWindowsHostAndContainerCompat(host, ctr windowsOSVersion) bool {
 	}
 
 	// If host is < WS 2022, exact version match is required
-	if host.Build < v21H2Server {
+	if host.Build < ltsc2022 {
 		return host.Build == ctr.Build
 	}
 
-	var supportedLtscRelease uint16
+	// Find the latest LTSC version that is earlier than the host version.
+	// This is the earliest version of container that the host can run.
+	//
+	// If the host version is an LTSC, then it supports compatibility with
+	// everything from the previous LTSC up to itself, so we want supportedLTSCRelease
+	// to be the previous entry.
+	//
+	// If no match is found, then we know that the host is LTSC2022 exactly,
+	// since we already checked that it's not less than LTSC2022.
+	var supportedLTSCRelease uint16 = ltsc2022
 	for i := len(compatLTSCReleases) - 1; i >= 0; i-- {
-		if host.Build >= compatLTSCReleases[i] {
-			supportedLtscRelease = compatLTSCReleases[i]
+		if host.Build > compatLTSCReleases[i] {
+			supportedLTSCRelease = compatLTSCReleases[i]
 			break
 		}
 	}
-	return ctr.Build >= supportedLtscRelease && ctr.Build <= host.Build
+	return supportedLTSCRelease <= ctr.Build && ctr.Build <= host.Build
 }
 
 func getWindowsOSVersion(osVersionPrefix string) windowsOSVersion {

--- a/platform_windows_compat_test.go
+++ b/platform_windows_compat_test.go
@@ -17,68 +17,96 @@
 package platforms
 
 import (
+	"fmt"
 	"testing"
 )
 
-// Test the platform compatibility of the different
-// OS Versions considering two ltsc container image
-// versions (ltsc2019, ltsc2022)
+// Test the platform compatibility of the different OS Versions
 func Test_PlatformCompat(t *testing.T) {
-	for testName, tc := range map[string]struct {
-		hostOs    uint16
-		ctrOs     uint16
+	for _, tc := range []struct {
+		hostOS    uint16
+		ctrOS     uint16
 		shouldRun bool
 	}{
-		"RS5Host_ltsc2019": {
-			hostOs:    rs5,
-			ctrOs:     rs5,
+		{
+			hostOS:    ltsc2019,
+			ctrOS:     ltsc2019,
 			shouldRun: true,
 		},
-		"RS5Host_ltsc2022": {
-			hostOs:    rs5,
-			ctrOs:     v21H2Server,
+		{
+			hostOS:    ltsc2019,
+			ctrOS:     ltsc2022,
 			shouldRun: false,
 		},
-		"WS2022Host_ltsc2019": {
-			hostOs:    v21H2Server,
-			ctrOs:     rs5,
+		{
+			hostOS:    ltsc2022,
+			ctrOS:     ltsc2019,
 			shouldRun: false,
 		},
-		"WS2022Host_ltsc2022": {
-			hostOs:    v21H2Server,
-			ctrOs:     v21H2Server,
+		{
+			hostOS:    ltsc2022,
+			ctrOS:     ltsc2022,
 			shouldRun: true,
 		},
-		"Wind11Host_ltsc2019": {
-			hostOs:    v22H2Win11,
-			ctrOs:     rs5,
+		{
+			hostOS:    v22H2Win11,
+			ctrOS:     ltsc2019,
 			shouldRun: false,
 		},
-		"Wind11Host_ltsc2022": {
-			hostOs:    v22H2Win11,
-			ctrOs:     v21H2Server,
+		{
+			hostOS:    v22H2Win11,
+			ctrOS:     ltsc2022,
+			shouldRun: true,
+		},
+		{
+			hostOS:    v23H2,
+			ctrOS:     ltsc2019,
+			shouldRun: false,
+		},
+		{
+			hostOS:    v23H2,
+			ctrOS:     ltsc2022,
+			shouldRun: true,
+		},
+		{
+			hostOS:    ltsc2025,
+			ctrOS:     ltsc2022,
+			shouldRun: true,
+		},
+		{
+			hostOS:    ltsc2022,
+			ctrOS:     ltsc2025,
+			shouldRun: false,
+		},
+		{
+			hostOS:    ltsc2022,
+			ctrOS:     v22H2Win11,
+			shouldRun: false,
+		},
+		{
+			hostOS:    ltsc2025,
+			ctrOS:     v22H2Win11,
 			shouldRun: true,
 		},
 	} {
-		// Check if ltsc2019/ltsc2022 guest images are compatible on
-		// the given host OS versions
-		//
-		hostOSVersion := windowsOSVersion{
-			MajorVersion: 10,
-			MinorVersion: 0,
-			Build:        tc.hostOs,
-		}
-		ctrOSVersion := windowsOSVersion{
-			MajorVersion: 10,
-			MinorVersion: 0,
-			Build:        tc.ctrOs,
-		}
-		if checkWindowsHostAndContainerCompat(hostOSVersion, ctrOSVersion) != tc.shouldRun {
-			var expectedResultStr string
-			if !tc.shouldRun {
-				expectedResultStr = " NOT"
+		t.Run(fmt.Sprintf("Host_%d_Ctr_%d", tc.hostOS, tc.ctrOS), func(t *testing.T) {
+			hostOSVersion := windowsOSVersion{
+				MajorVersion: 10,
+				MinorVersion: 0,
+				Build:        tc.hostOS,
 			}
-			t.Fatalf("Failed %v: host %v should%s be able to run guest %v", testName, tc.hostOs, expectedResultStr, tc.ctrOs)
-		}
+			ctrOSVersion := windowsOSVersion{
+				MajorVersion: 10,
+				MinorVersion: 0,
+				Build:        tc.ctrOS,
+			}
+			if checkWindowsHostAndContainerCompat(hostOSVersion, ctrOSVersion) != tc.shouldRun {
+				var expectedResultStr string
+				if !tc.shouldRun {
+					expectedResultStr = " NOT"
+				}
+				t.Fatalf("host %v should%s be able to run guest %v", tc.hostOS, expectedResultStr, tc.ctrOS)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Commit primarily adds WS2025 to windows matcher and updates test. Similar to what we updated on hcsshim osversion package.