### PR TITLE
Add some limits to os-features

### DIFF
--- a/platforms.go
+++ b/platforms.go
@@ -127,6 +127,18 @@ var (
 	osRe        = regexp.MustCompile(`^([A-Za-z0-9_-]+)(?:\(([A-Za-z0-9_.%-]*)((?:\+[A-Za-z0-9_.%-]+)*)\))?$`)
 )
 
+const (
+	maxFeatures     = 16  // maxFeatures is the maximum number of features allowed.
+	maxFeatureLen   = 64  // maxFeatureLen is the maximum length per feature.
+	maxOSOptionsLen = 256 // maxOSOptionsLen is the maximum length for OS options (OS-version + options).
+)
+
+var (
+	errTooManyFeatures  = fmt.Errorf("too many os features: %w", errInvalidArgument)
+	errFeatureTooLong   = fmt.Errorf("os feature too long: %w", errInvalidArgument)
+	errOSOptionsTooLong = fmt.Errorf("os options too long: %w", errInvalidArgument)
+)
+
 // Platform is a type alias for convenience, so there is no need to import image-spec package everywhere.
 type Platform = specs.Platform
 
@@ -352,12 +364,21 @@ func parseOSFeatures(s string) ([]string, error) {
 	if s == "" {
 		return nil, nil
 	}
+	if len(s) > maxOSOptionsLen {
+		return nil, errOSOptionsTooLong
+	}
 
-	var features []string
+	features := make([]string, 0, min(strings.Count(s, "+")+1, maxFeatures))
 	for raw := range strings.SplitSeq(s, "+") {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
 			return nil, fmt.Errorf("empty os feature: %w", errInvalidArgument)
+		}
+		if len(features) == maxFeatures {
+			return nil, errTooManyFeatures
+		}
+		if len(raw) > maxFeatureLen {
+			return nil, errFeatureTooLong
 		}
 		feature, err := decodeOSOption(raw)
 		if err != nil {
@@ -404,7 +425,7 @@ func FormatAll(platform specs.Platform) string {
 	var b strings.Builder
 	b.WriteString(platform.OS)
 	osv := encodeOSOption(platform.OSVersion)
-	formatted := formatOSFeatures(platform.OSFeatures)
+	formatted, _ := formatOSFeatures(osv, platform.OSFeatures)
 	if osv != "" || formatted != "" {
 		b.Grow(len(osv) + len(formatted) + 3) // parens + maybe '+'
 		b.WriteByte('(')
@@ -421,9 +442,12 @@ func FormatAll(platform specs.Platform) string {
 	return path.Join(b.String(), platform.Architecture, platform.Variant)
 }
 
-func formatOSFeatures(features []string) string {
+func formatOSFeatures(osVersion string, features []string) (string, error) {
 	if len(features) == 0 {
-		return ""
+		return "", nil
+	}
+	if len(features) > maxFeatures {
+		return "", errTooManyFeatures
 	}
 
 	if !slices.IsSorted(features) {
@@ -438,14 +462,21 @@ func formatOSFeatures(features []string) string {
 			// skip empty and duplicate values
 			continue
 		}
+		if len(f) > maxFeatureLen {
+			return "", errFeatureTooLong
+		}
 		prev = f
 		if wrote {
 			b.WriteByte('+')
 		}
-		b.WriteString(encodeOSOption(f))
+		encoded := encodeOSOption(f)
+		if len(osVersion)+b.Len()+len(encoded) > maxOSOptionsLen {
+			return "", errOSOptionsTooLong
+		}
+		b.WriteString(encoded)
 		wrote = true
 	}
-	return b.String()
+	return b.String(), nil
 }
 
 // osOptionReplacer encodes characters in OS option values (version and

--- a/platforms_test.go
+++ b/platforms_test.go
@@ -605,8 +605,6 @@ func FuzzPlatformsParse(f *testing.F) {
 }
 
 func BenchmarkParseOSOptions(b *testing.B) {
-	maxFeatures := 16
-
 	benchmarks := []struct {
 		doc   string
 		input string
@@ -641,8 +639,6 @@ func BenchmarkParseOSOptions(b *testing.B) {
 }
 
 func BenchmarkFormatAllOSFeatures(b *testing.B) {
-	maxFeatures := 16
-
 	benchmarks := []struct {
 		doc      string
 		platform specs.Platform


### PR DESCRIPTION
- [x] follow-up to / stacked on https://github.com/containerd/platforms/pull/30


### Add some limits to os-features


----

Baseline -> https://github.com/containerd/platforms/pull/30 -> this PR;


```console
goos: darwin
goarch: arm64
pkg: github.com/containerd/platforms
cpu: Apple M3 Pro
                                                             │   before.txt   │              after.txt              │
                                                             │     sec/op     │   sec/op     vs base                │
ParseOSOptions/valid_windows_version_and_feature                  576.1n ± 3%   570.1n ± 1%        ~ (p=0.101 n=10)
ParseOSOptions/valid_but_lengthy_features                         1.879µ ± 0%   1.884µ ± 1%        ~ (p=0.254 n=10)
ParseOSOptions/exploding_plus_chain                               518.0µ ± 0%   518.0µ ± 0%        ~ (p=0.912 n=10)
ParseOSOptions/kernel_config_feature_blob                         775.0µ ± 1%   775.0µ ± 1%        ~ (p=0.971 n=10)
FormatAllOSFeatures/plain_linux_amd64                             39.66n ± 1%   38.89n ± 2%   -1.93% (p=0.000 n=10)
FormatAllOSFeatures/windows_version_and_feature                   136.0n ± 1%   137.1n ± 1%   +0.77% (p=0.011 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                    151.1n ± 1%   151.5n ± 1%        ~ (p=0.424 n=10)
FormatAllOSFeatures/skips_empty_features                          170.0n ± 1%   172.5n ± 1%   +1.47% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                 74986.00n ± 2%   59.92n ± 1%  -99.92% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   71413.50n ± 1%   59.02n ± 1%  -99.92% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                             88.63n ± 1%   59.05n ± 2%  -33.37% (p=0.000 n=10)
geomean                                                           2.542µ        671.7n       -73.57%

                                                             │   before.txt   │               after.txt                │
                                                             │      B/op      │     B/op      vs base                  │
ParseOSOptions/valid_windows_version_and_feature                   208.0 ± 0%     208.0 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/valid_but_lengthy_features                        1.109Ki ± 0%   1.109Ki ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                              496.4Ki ± 0%   496.4Ki ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                        720.4Ki ± 0%   720.4Ki ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                              16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                    160.0 ± 0%     160.0 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/valid_but_lengthy_features                     72.00 ± 0%     72.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/skips_empty_features                           136.0 ± 0%     136.0 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/kernel_config_feature_blob                 294920.00 ± 0%     24.00 ± 0%  -99.99% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   124408.00 ± 0%     24.00 ± 0%  -99.98% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                              24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                          1.945Ki          388.8       -80.48%
¹ all samples are equal

                                                             │ before.txt  │              after.txt               │
                                                             │  allocs/op  │ allocs/op   vs base                  │
ParseOSOptions/valid_windows_version_and_feature                4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/valid_but_lengthy_features                       10.00 ± 0%   10.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                             12.00 ± 0%   12.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                       13.00 ± 0%   13.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                           1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                 5.000 ± 0%   5.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/valid_but_lengthy_features                  4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/skips_empty_features                        5.000 ± 0%   5.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/kernel_config_feature_blob                  5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   21.000 ± 0%   2.000 ± 0%  -90.48% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                           2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                         5.469        4.064       -25.70%
¹ all samples are equal
```


Compared to baseline (before https://github.com/containerd/platforms/pull/30)

<details>

```console
goos: darwin
goarch: arm64
pkg: github.com/containerd/platforms
cpu: Apple M3 Pro
                                                             │  baseline.txt   │              after.txt              │
                                                             │     sec/op      │   sec/op     vs base                │
ParseOSOptions/valid_windows_version_and_feature                   583.3n ± 2%   570.1n ± 1%   -2.27% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                          1.879µ ± 1%   1.884µ ± 1%        ~ (p=0.567 n=10)
ParseOSOptions/exploding_plus_chain                                518.0µ ± 0%   518.0µ ± 0%        ~ (p=0.971 n=10)
ParseOSOptions/kernel_config_feature_blob                          775.9µ ± 0%   775.0µ ± 1%        ~ (p=0.796 n=10)
FormatAllOSFeatures/plain_linux_amd64                              41.93n ± 1%   38.89n ± 2%   -7.26% (p=0.000 n=10)
FormatAllOSFeatures/windows_version_and_feature                    204.0n ± 1%   137.1n ± 1%  -32.78% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                     911.3n ± 1%   151.5n ± 1%  -83.37% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                           295.4n ± 1%   172.5n ± 1%  -41.61% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                  79846.50n ± 0%   59.92n ± 1%  -99.92% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   574006.00n ± 1%   59.02n ± 1%  -99.99% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                             610.55n ± 1%   59.05n ± 2%  -90.33% (p=0.000 n=10)
geomean                                                            4.760µ        671.7n       -85.89%

                                                             │  baseline.txt   │                after.txt                │
                                                             │      B/op       │     B/op      vs base                   │
ParseOSOptions/valid_windows_version_and_feature                    224.0 ± 0%     208.0 ± 0%    -7.14% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                         1.109Ki ± 0%   1.109Ki ± 0%         ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                               496.4Ki ± 0%   496.4Ki ± 0%         ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                         720.4Ki ± 0%   720.4Ki ± 0%         ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                               16.00 ± 0%     16.00 ± 0%         ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                     184.0 ± 0%     160.0 ± 0%   -13.04% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                    1776.00 ± 0%     72.00 ± 0%   -95.95% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                            176.0 ± 0%     136.0 ± 0%   -22.73% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                  368697.00 ± 0%     24.00 ± 0%   -99.99% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   6881844.50 ± 0%     24.00 ± 0%  -100.00% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                              272.00 ± 0%     24.00 ± 0%   -91.18% (p=0.000 n=10)
geomean                                                           4.980Ki          388.8        -92.37%
¹ all samples are equal

                                                             │ baseline.txt  │              after.txt               │
                                                             │   allocs/op   │ allocs/op   vs base                  │
ParseOSOptions/valid_windows_version_and_feature                  5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                         10.00 ± 0%   10.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                               12.00 ± 0%   12.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                         13.00 ± 0%   13.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                             1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                   6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                   22.000 ± 0%   4.000 ± 0%  -81.82% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                          8.000 ± 0%   5.000 ± 0%  -37.50% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                    8.000 ± 0%   2.000 ± 0%  -75.00% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   1034.000 ± 0%   2.000 ± 0%  -99.81% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                            20.000 ± 0%   2.000 ± 0%  -90.00% (p=0.000 n=10)
geomean                                                           12.68        4.064       -67.95%
¹ all samples are equal
```

</details>