### PR TITLE
refactor, optimize FormatAll, ParseAll

### DIFF
--- a/cpuinfo_linux.go
+++ b/cpuinfo_linux.go
@@ -45,7 +45,6 @@ func getMachineArch() (string, error) {
 // So we don't need to access the ARM registers to detect platform information
 // by ourselves. We can just parse these information from /proc/cpuinfo
 func getCPUInfo(pattern string) (info string, err error) {
-
 	cpuinfo, err := os.Open("/proc/cpuinfo")
 	if err != nil {
 		return "", err
@@ -75,7 +74,6 @@ func getCPUInfo(pattern string) (info string, err error) {
 
 // getCPUVariantFromArch get CPU variant from arch through a system call
 func getCPUVariantFromArch(arch string) (string, error) {
-
 	var variant string
 
 	arch = strings.ToLower(arch)

--- a/cpuinfo_linux_test.go
+++ b/cpuinfo_linux_test.go
@@ -46,7 +46,6 @@ func TestCPUVariant(t *testing.T) {
 }
 
 func TestGetCPUVariantFromArch(t *testing.T) {
-
 	for _, testcase := range []struct {
 		name        string
 		input       string
@@ -127,13 +126,11 @@ func TestGetCPUVariantFromArch(t *testing.T) {
 						t.Fatalf("Expect to get variant: %v, however %v returned", testcase.output, variant)
 					}
 				}
-
 			} else {
 				if !errors.Is(err, testcase.expectedErr) {
 					t.Fatalf("Expect to get error: %v, however error %v returned", testcase.expectedErr, err)
 				}
 			}
 		})
-
 	}
 }

--- a/cpuinfo_other.go
+++ b/cpuinfo_other.go
@@ -24,7 +24,6 @@ import (
 )
 
 func getCPUVariant() (string, error) {
-
 	var variant string
 
 	switch runtime.GOOS {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/platforms
 
-go 1.21
+go 1.24
 
 require (
 	github.com/containerd/log v0.1.0

--- a/platform_windows_compat_test.go
+++ b/platform_windows_compat_test.go
@@ -183,5 +183,4 @@ func Test_PlatformOrder(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/platforms.go
+++ b/platforms.go
@@ -280,13 +280,9 @@ func Parse(specifier string) (specs.Platform, error) {
 			}
 			p.OSVersion = osVersion
 			if osOptions[3] != "" {
-				rawFeatures := strings.Split(osOptions[3][1:], "+")
-				p.OSFeatures = make([]string, len(rawFeatures))
-				for i, f := range rawFeatures {
-					p.OSFeatures[i], err = decodeOSOption(f)
-					if err != nil {
-						return specs.Platform{}, fmt.Errorf("%q has an invalid OS feature %q: %w", specifier, f, err)
-					}
+				p.OSFeatures, err = parseOSFeatures(osOptions[3][1:])
+				if err != nil {
+					return specs.Platform{}, fmt.Errorf("%q has invalid OS features: %w", specifier, err)
 				}
 			}
 		} else {
@@ -346,6 +342,30 @@ func Parse(specifier string) (specs.Platform, error) {
 	return specs.Platform{}, fmt.Errorf("%q: cannot parse platform specifier: %w", specifier, errInvalidArgument)
 }
 
+func parseOSFeatures(s string) ([]string, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	var features []string
+	for raw := range strings.SplitSeq(s, "+") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil, fmt.Errorf("empty os feature: %w", errInvalidArgument)
+		}
+		feature, err := decodeOSOption(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid os feature %q: %w", raw, err)
+		}
+		if feature == "" {
+			continue
+		}
+		features = append(features, feature)
+	}
+
+	return features, nil
+}
+
 // MustParse is like Parses but panics if the specifier cannot be parsed.
 // Simplifies initialization of global variables.
 func MustParse(specifier string) specs.Platform {
@@ -370,6 +390,9 @@ func Format(platform specs.Platform) string {
 func FormatAll(platform specs.Platform) string {
 	if platform.OS == "" {
 		return "unknown"
+	}
+	if platform.OSVersion == "" && len(platform.OSFeatures) == 0 {
+		return path.Join(platform.OS, platform.Architecture, platform.Variant)
 	}
 
 	var b strings.Builder

--- a/platforms.go
+++ b/platforms.go
@@ -373,20 +373,50 @@ func FormatAll(platform specs.Platform) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(encodeOSOption(platform.OSVersion))
-	features := platform.OSFeatures
+	b.WriteString(platform.OS)
+	osv := encodeOSOption(platform.OSVersion)
+	formatted := formatOSFeatures(platform.OSFeatures)
+	if osv != "" || formatted != "" {
+		b.Grow(len(osv) + len(formatted) + 3) // parens + maybe '+'
+		b.WriteByte('(')
+		if osv != "" {
+			b.WriteString(osv)
+		}
+		if formatted != "" {
+			b.WriteByte('+')
+			b.WriteString(formatted)
+		}
+		b.WriteByte(')')
+	}
+
+	return path.Join(b.String(), platform.Architecture, platform.Variant)
+}
+
+func formatOSFeatures(features []string) string {
+	if len(features) == 0 {
+		return ""
+	}
+
 	if !slices.IsSorted(features) {
 		features = slices.Clone(features)
 		slices.Sort(features)
 	}
+	var b strings.Builder
+	var wrote bool
+	var prev string
 	for _, f := range features {
-		b.WriteString("+" + encodeOSOption(f))
+		if f == "" || f == prev {
+			// skip empty and duplicate values
+			continue
+		}
+		prev = f
+		if wrote {
+			b.WriteByte('+')
+		}
+		b.WriteString(encodeOSOption(f))
+		wrote = true
 	}
-	if b.Len() > 0 {
-		osAndVersion := platform.OS + "(" + b.String() + ")"
-		return path.Join(osAndVersion, platform.Architecture, platform.Variant)
-	}
-	return path.Join(platform.OS, platform.Architecture, platform.Variant)
+	return b.String()
 }
 
 // osOptionReplacer encodes characters in OS option values (version and

--- a/platforms.go
+++ b/platforms.go
@@ -372,18 +372,19 @@ func FormatAll(platform specs.Platform) string {
 		return "unknown"
 	}
 
-	osOptions := encodeOSOption(platform.OSVersion)
+	var b strings.Builder
+	b.WriteString(encodeOSOption(platform.OSVersion))
 	features := platform.OSFeatures
 	if !slices.IsSorted(features) {
 		features = slices.Clone(features)
 		slices.Sort(features)
 	}
 	for _, f := range features {
-		osOptions += "+" + encodeOSOption(f)
+		b.WriteString("+" + encodeOSOption(f))
 	}
-	if osOptions != "" {
-		OSAndVersion := fmt.Sprintf("%s(%s)", platform.OS, osOptions)
-		return path.Join(OSAndVersion, platform.Architecture, platform.Variant)
+	if b.Len() > 0 {
+		osAndVersion := platform.OS + "(" + b.String() + ")"
+		return path.Join(osAndVersion, platform.Architecture, platform.Variant)
 	}
 	return path.Join(platform.OS, platform.Architecture, platform.Variant)
 }

--- a/platforms_test.go
+++ b/platforms_test.go
@@ -20,6 +20,8 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -578,6 +580,20 @@ func TestParseSelectorInvalid(t *testing.T) {
 	}
 }
 
+func TestFormatAllSkipsEmptyOSFeatures(t *testing.T) {
+	p := specs.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+		OSFeatures:   []string{"", "gpu", "", "simd"},
+	}
+
+	formatted := FormatAll(p)
+	expected := "linux(+gpu+simd)/amd64"
+	if formatted != expected {
+		t.Fatalf("unexpected format: %q != %q", formatted, expected)
+	}
+}
+
 func FuzzPlatformsParse(f *testing.F) {
 	f.Add("linux/amd64")
 	f.Fuzz(func(t *testing.T, s string) {
@@ -586,4 +602,132 @@ func FuzzPlatformsParse(f *testing.F) {
 			t.Errorf("either %+v or %+v must be nil", err, pf)
 		}
 	})
+}
+
+func BenchmarkParseOSOptions(b *testing.B) {
+	maxFeatures := 16
+
+	benchmarks := []struct {
+		doc   string
+		input string
+	}{
+		{
+			doc:   "valid windows version and feature",
+			input: "windows(10.0.17763+win32k)/amd64",
+		},
+		{
+			doc:   "valid but lengthy features",
+			input: "linux(+" + strings.Repeat("+feature", maxFeatures) + ")/amd64",
+		},
+		{
+			doc:   "exploding plus chain",
+			input: "linux(" + strings.Repeat("+", 64*1024) + ")/amd64",
+		},
+		{
+			doc:   "kernel config feature blob",
+			input: "linux(+CONFIG_" + strings.Repeat("FOO=y_", 16*1024) + "BAR)/amd64",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, bm := range benchmarks {
+		b.Run(bm.doc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = Parse(bm.input)
+			}
+		})
+	}
+}
+
+func BenchmarkFormatAllOSFeatures(b *testing.B) {
+	maxFeatures := 16
+
+	benchmarks := []struct {
+		doc      string
+		platform specs.Platform
+	}{
+		{
+			doc: "plain linux amd64",
+			platform: specs.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "windows version and feature",
+			platform: specs.Platform{
+				OS:           "windows",
+				OSVersion:    "10.0.17763",
+				OSFeatures:   []string{"win32k"},
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "valid but lengthy features",
+			platform: specs.Platform{
+				OS: "linux",
+				OSFeatures: func() (out []string) {
+					for i := 0; i <= maxFeatures; i++ {
+						out = append(out, "feature")
+					}
+					return out
+				}(),
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "skips empty features",
+			platform: specs.Platform{
+				OS:           "linux",
+				OSFeatures:   []string{"", "gpu", "", "simd"},
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "kernel config feature blob",
+			platform: specs.Platform{
+				OS:           "linux",
+				OSFeatures:   []string{"CONFIG_" + strings.Repeat("FOO_", 16*1024) + "BAR"},
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "many kernel config features with empties",
+			platform: specs.Platform{
+				OS: "linux",
+				OSFeatures: func() []string {
+					n := 1024
+					out := make([]string, n)
+					for i := range out {
+						if i%10 == 0 {
+							out[i] = "" // simulate bad data
+						} else {
+							out[i] = "CONFIG_FOO_" + strconv.Itoa(i)
+						}
+					}
+					return out
+				}(),
+				Architecture: "amd64",
+			},
+		},
+		{
+			doc: "too many features",
+			platform: specs.Platform{
+				OS:           "linux",
+				OSFeatures:   make([]string, maxFeatures+1),
+				Architecture: "amd64",
+			},
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, bm := range benchmarks {
+		b.Run(bm.doc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = FormatAll(bm.platform)
+			}
+		})
+	}
 }

--- a/platforms_test.go
+++ b/platforms_test.go
@@ -633,7 +633,7 @@ func BenchmarkParseOSOptions(b *testing.B) {
 	b.ResetTimer()
 	for _, bm := range benchmarks {
 		b.Run(bm.doc, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, _ = Parse(bm.input)
 			}
 		})
@@ -668,7 +668,7 @@ func BenchmarkFormatAllOSFeatures(b *testing.B) {
 			platform: specs.Platform{
 				OS: "linux",
 				OSFeatures: func() (out []string) {
-					for i := 0; i <= maxFeatures; i++ {
+					for range maxFeatures {
 						out = append(out, "feature")
 					}
 					return out
@@ -725,7 +725,7 @@ func BenchmarkFormatAllOSFeatures(b *testing.B) {
 	b.ResetTimer()
 	for _, bm := range benchmarks {
 		b.Run(bm.doc, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = FormatAll(bm.platform)
 			}
 		})


### PR DESCRIPTION
### gofumpt code

### add benchmark for Parse, FormatAll


### go.mod: bump minimum go version to go1.24


### modernize --fix


### FormatAll: use a string-builder for formatting os-options


### ParseAll: refactor

Avoid using `strings.Split`, and error on empty values.



Before/after:

```console
goos: darwin
goarch: arm64
pkg: github.com/containerd/platforms
cpu: Apple M3 Pro
                                                             │  before.txt  │              after.txt              │
                                                             │    sec/op    │   sec/op     vs base                │
ParseOSOptions/valid_windows_version_and_feature                611.7n ± 2%   567.0n ± 3%   -7.31% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                       1.956µ ± 1%   1.838µ ± 2%   -6.06% (p=0.000 n=10)
ParseOSOptions/exploding_plus_chain                             534.6µ ± 1%   512.1µ ± 0%   -4.21% (p=0.000 n=10)
ParseOSOptions/kernel_config_feature_blob                       803.4µ ± 2%   768.1µ ± 1%   -4.39% (p=0.000 n=10)
FormatAllOSFeatures/plain_linux_amd64                           43.26n ± 1%   38.53n ± 1%  -10.94% (p=0.000 n=10)
FormatAllOSFeatures/windows_version_and_feature                 208.9n ± 2%   135.8n ± 1%  -35.01% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                  937.4n ± 1%   150.1n ± 1%  -83.99% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                        305.9n ± 1%   171.1n ± 2%  -44.07% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                  82.32µ ± 1%   74.79µ ± 1%   -9.15% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   595.03µ ± 1%   72.44µ ± 1%  -87.83% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                          620.65n ± 2%   89.29n ± 1%  -85.61% (p=0.000 n=10)
geomean                                                         4.916µ        2.525µ       -48.63%

                                                             │  before.txt   │               after.txt                │
                                                             │     B/op      │     B/op      vs base                  │
ParseOSOptions/valid_windows_version_and_feature                  224.0 ± 0%     208.0 ± 0%   -7.14% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                       1.109Ki ± 0%   1.109Ki ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                             496.4Ki ± 0%   496.4Ki ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                       720.4Ki ± 0%   720.4Ki ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                             16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                   184.0 ± 0%     160.0 ± 0%  -13.04% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                  1776.00 ± 0%     72.00 ± 0%  -95.95% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                          176.0 ± 0%     136.0 ± 0%  -22.73% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                  360.1Ki ± 0%   288.0Ki ± 0%  -20.01% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   6720.5Ki ± 0%   121.5Ki ± 0%  -98.19% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                            272.00 ± 0%     24.00 ± 0%  -91.18% (p=0.000 n=10)
geomean                                                         4.980Ki        1.945Ki       -60.94%
¹ all samples are equal

                                                             │  before.txt  │              after.txt               │
                                                             │  allocs/op   │ allocs/op   vs base                  │
ParseOSOptions/valid_windows_version_and_feature                 5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
ParseOSOptions/valid_but_lengthy_features                        10.00 ± 0%   10.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/exploding_plus_chain                              12.00 ± 0%   12.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseOSOptions/kernel_config_feature_blob                        13.00 ± 0%   13.00 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/plain_linux_amd64                            1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
FormatAllOSFeatures/windows_version_and_feature                  6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
FormatAllOSFeatures/valid_but_lengthy_features                  22.000 ± 0%   4.000 ± 0%  -81.82% (p=0.000 n=10)
FormatAllOSFeatures/skips_empty_features                         8.000 ± 0%   5.000 ± 0%  -37.50% (p=0.000 n=10)
FormatAllOSFeatures/kernel_config_feature_blob                   8.000 ± 0%   5.000 ± 0%  -37.50% (p=0.000 n=10)
FormatAllOSFeatures/many_kernel_config_features_with_empties   1034.00 ± 0%   21.00 ± 0%  -97.97% (p=0.000 n=10)
FormatAllOSFeatures/too_many_features                           20.000 ± 0%   2.000 ± 0%  -90.00% (p=0.000 n=10)
geomean                                                          12.68        5.469       -56.87%
¹ all samples are equal
```