### PR TITLE
Strip the win32k when comparing windows platforms

### DIFF
--- a/platform_windows_compat.go
+++ b/platform_windows_compat.go
@@ -17,6 +17,7 @@
 package platforms
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -161,4 +162,15 @@ func (c *windowsMatchComparer) Less(p1, p2 specs.Platform) bool {
 		return p1.OSVersion > p2.OSVersion
 	}
 	return m1 && !m2
+}
+
+type windowsStripFeaturesMatcher struct {
+	Matcher
+}
+
+func (m windowsStripFeaturesMatcher) Match(p specs.Platform) bool {
+	if i := slices.Index(p.OSFeatures, "win32k"); i >= 0 {
+		p.OSFeatures = slices.Delete(slices.Clone(p.OSFeatures), i, i+1)
+	}
+	return m.Matcher.Match(p)
 }

--- a/platforms.go
+++ b/platforms.go
@@ -156,6 +156,11 @@ func NewMatcher(platform specs.Platform) Matcher {
 		m.osvM = &windowsVersionMatcher{
 			windowsOSVersion: getWindowsOSVersion(platform.OSVersion),
 		}
+
+		// In prior versions, the win32k os feature was not considered for matching,
+		// strip out the win32k feature for comparison
+		var stripped Matcher = windowsStripFeaturesMatcher{m}
+
 		// In prior versions, on windows, the returned matcher implements a
 		// MatchComprarer interface.
 		// This preserves that behavior for backwards compatibility.
@@ -165,8 +170,9 @@ func NewMatcher(platform specs.Platform) Matcher {
 		// It was likely intended to be used in `Ordered` but it is not since
 		// `Less` that is implemented here ends up getting masked due to wrapping.
 		if runtime.GOOS == "windows" {
-			return &windowsMatchComparer{m}
+			return &windowsMatchComparer{stripped}
 		}
+		return stripped
 	}
 	return m
 }


### PR DESCRIPTION
Previously win32k was not considered when comparing Windows platforms, leading a failure to match against some existing images.

Fixes an issue with matching windows images from existing uses of the platforms library