### PR TITLE
Add win32k feature if available in default

### DIFF
--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -19,10 +19,26 @@ package platforms
 import (
 	"fmt"
 	"runtime"
+	"sync"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sys/windows"
 )
+
+var (
+	win32kOnce     sync.Once
+	win32kFeatures []string
+)
+
+func detectWin32k() []string {
+	win32kOnce.Do(func() {
+		user32 := windows.NewLazySystemDLL("user32.dll")
+		if err := user32.Load(); err == nil {
+			win32kFeatures = []string{"win32k"}
+		}
+	})
+	return win32kFeatures
+}
 
 // DefaultSpec returns the current platform's default platform specification.
 func DefaultSpec() specs.Platform {
@@ -31,6 +47,7 @@ func DefaultSpec() specs.Platform {
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
+		OSFeatures:   detectWin32k(),
 		// The Variant field will be empty if arch != ARM.
 		Variant: cpuVariant(),
 	}

--- a/defaults_windows_test.go
+++ b/defaults_windows_test.go
@@ -32,6 +32,7 @@ func TestDefault(t *testing.T) {
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		OSVersion:    fmt.Sprintf("%d.%d.%d", major, minor, build),
+		OSFeatures:   detectWin32k(),
 		Variant:      cpuVariant(),
 	}
 	p := DefaultSpec()


### PR DESCRIPTION
This probably the most correct thing to do but possibly not something we should do. Currently if we don't strip out the win32k feature, then it would have to be added manually to match images which have it set as a requirement.